### PR TITLE
Parametrized BPX dz gap + Tracker volume fix to match https://github.com/cms-sw/cmssw/pull/43133

### DIFF
--- a/geometries/CMS_Phase2/OT806_IT741.cfg
+++ b/geometries/CMS_Phase2/OT806_IT741.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V806.cfg
+@include Pixel/Pixel_V7/Pixel_V7_4_1.cfg

--- a/geometries/CMS_Phase2/OT806_IT742.cfg
+++ b/geometries/CMS_Phase2/OT806_IT742.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V806.cfg
+@include Pixel/Pixel_V7/Pixel_V7_4_2.cfg

--- a/geometries/CMS_Phase2/OT806_IT743.cfg
+++ b/geometries/CMS_Phase2/OT806_IT743.cfg
@@ -1,0 +1,3 @@
+@include-std CMS_Phase2/SimParms
+@include OuterTracker/Tilted/OT_V806.cfg
+@include Pixel/Pixel_V7/Pixel_V7_4_3.cfg

--- a/geometries/CMS_Phase2/Pixel/Pixel_V7/BPIX_7_4_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V7/BPIX_7_4_2.cfg
@@ -1,0 +1,79 @@
+Barrel PXB { // 7_4_2 implementing variable z gaps
+    trackingTags pixel,tracker
+      
+    @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/TBPX_Supports.cfg
+    @include-std CMS_Phase2/Pixel/Conversions/On_flange/flange_BPIX
+    @include-std CMS_Phase2/Pixel/Conversions/On_services_cylinder/stations_serving_TBPX_614
+    
+    beamSpotCover false
+    smallDelta 0 
+    numLayers 4
+    startZMode modulecenter
+    numModules 5  // 4 on the right and 4 on the left and a central one
+    compressed false
+    innerRadius 30
+    outerRadius 146.5
+
+    smallParity 1
+    bigParity 1
+ 
+    
+    isSkewedForInstallation true    // Skewed mode.
+    skewedModuleEdgeShift 5         // Shift of the edge of each skewed module.
+    installationOverlapRatio 2      // Ratio between the angular overlap around the (X=0) plane and the angular overlap between 2 standard consecutive rods.
+
+    Layer 1 {
+      bigDelta 2.5
+      zOverlap -0.75 // 0.75 mm space between active areas: 0.175 mm dead area on each sensor side + 0.4 mm gap
+   //   zOverlap -2.15 // 0.75 mm space between active areas: 0.175 mm dead area on each sensor side + 0.4 + 2*0.7  mm gap
+      zGap 0.7 
+      zCentral -21.125
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_wide_2sens_3D
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L1_1x2_2500_3D
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L1
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX1
+      numRods 12
+    }
+    //modZList -178.30,-133.90,-89.50,-45.10,0.7,45.10,89.50,133.90,178.30 
+    Layer 2 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.45 mm dead area on each sensor side + 0.4 mm gap
+      zGap 0.7 
+      zCentral -22.425
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_1x2_25x100_v202305
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L2_1x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L2
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX2
+      radiusMode fixed
+      placeRadiusHint 61.5
+      numRods 24
+    }
+    Layer 3 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.45 mm dead area on each sensor side + 0.4 mm gap
+      zGap 0.7 
+      zCentral -21.025
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_v202305
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L3_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L3
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX3
+      radiusMode fixed
+      placeRadiusHint 104.5
+      numRods 20
+    }
+    Layer 4 {
+      bigDelta 2.5
+      zOverlap -1.3 // 1.3 mm space between active areas: 0.45 mm dead area on each sensor side + 0.4 mm gap
+      zGap 0.7 
+      zCentral -22.425
+      @include-std CMS_Phase2/Pixel/ModuleTypes/pixel_2x2_25x100_v202305
+      @include-std CMS_Phase2/Pixel/Materials/module_BPIX_L4_2x2_2500
+      @include-std CMS_Phase2/Pixel/Materials/rod_BPIX_L4
+      @include-std CMS_Phase2/Pixel/Resolutions/25x100
+      destination BPIX4
+      numRods 28
+    }
+  }

--- a/geometries/CMS_Phase2/Pixel/Pixel_V7/Pixel_V7_4_2.cfg
+++ b/geometries/CMS_Phase2/Pixel/Pixel_V7/Pixel_V7_4_2.cfg
@@ -1,0 +1,27 @@
+
+Tracker Pixels {
+
+  etaCut 10
+  zError 70
+
+  smallDelta 0
+  bigDelta 3
+
+  servicesForcedUp false
+
+  rotateBarrelByHalfPi true
+  
+  @include-std CMS_Phase2/Pixel/moduleOperatingParms
+  
+  barrelDetIdScheme Phase2Subdetector1
+  endcapDetIdScheme Phase2Subdetector4
+  
+  @include BPIX_7_4_2.cfg
+  @include ../Pixel_V6/FPIX1_6_4_0.cfg
+  @include ../Pixel_V6/FPIX2_6_1_3.cfg
+
+
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Support_Tube.cfg
+  @include-std CMS_Phase2/Pixel/Materials/MechanicalSupports/IT_Service_Cylinder.cfg
+
+}

--- a/include/RodPair.hh
+++ b/include/RodPair.hh
@@ -139,6 +139,7 @@ class StraightRodPair : public RodPair, public Clonable<StraightRodPair> {
   double computeNextZ(double newDsLength, double newDsDistance, double lastDsDistance, double lastZ, BuildDir direction, int parity);
   template<typename Iterator> vector<double> computeZList(Iterator begin, Iterator end, double startZ, BuildDir direction, int smallParity, bool fixedStartZ);
   template<typename Iterator> pair<vector<double>, vector<double>> computeZListPair(Iterator begin, Iterator end, double startZ, int recursionCounter);
+//  template<typename Iterator> pair<vector<double>, vector<double>> computeZListPair(Iterator begin, Iterator end,ReadonlyPropertyVector<std::vector<double> > zPlusList, ReadonlyPropertyVector<std::vector<double> > zMinusList);
   void buildModules(Container& modules, const RodTemplate& rodTemplate, const vector<double>& posList, BuildDir direction, bool isPlusBigDeltaRod, int parity, int side);
   void buildFull(const RodTemplate& rodTemplate, bool isPlusBigDeltaRod); 
   void buildMezzanine(const RodTemplate& rodTemplate, bool isPlusBigDeltaRod); 
@@ -151,6 +152,8 @@ public:
   Property<double, NoDefault> maxBuildRadius;
 
   Property<double, Default> zOverlap;
+  Property<double, Default> zGap;
+  Property<double, Default> zCentral;
   Property<double, NoDefault> zError;
   Property<int, NoDefault> zPlusParity;
   Property<int, NoDefault> buildNumModules;
@@ -163,10 +166,18 @@ public:
 
   PropertyNode<int> ringNode;
   
+  //ReadonlyPropertyVector<std::vector<double>,',' > zPlusList;
+ // ReadonlyPropertyVector<std::vector<double>, ',' > zMinusList;
+ 
+//  std::vector<double> zPlusList ={0.70,45.10,89.50,133.90,178.30};
+//  std::vector<double> zMinusList={-45.10,-89.50,-133.90,-178.30};
+  
   StraightRodPair(const std::string subdetectorName) :
               RodPair             (subdetectorName),
               forbiddenRange      ("forbiddenRange"      , parsedOnly()),
               zOverlap            ("zOverlap"            , parsedAndChecked() , 1.),
+              zGap                ("zGap"                , parsedOnly() , 0.),
+              zCentral            ("zCentral"            , parsedOnly() , -999),
 	      zError              ("zError"              , parsedAndChecked()),
 	      zPlusParity         ("smallParity"         , parsedOnly()),
               mezzanine           ("mezzanine"           , parsedOnly(), false),
@@ -175,6 +186,8 @@ public:
               allowCompressionCuts("allowCompressionCuts", parsedOnly(), true),
 	      isFlatPart          ("isFlatPart"          , parsedOnly(), false),
 	      ringNode            ("Ring"                , parsedOnly())
+//	      zPlusList           ("zPlusList"           , parsedOnly()),
+//	      zMinusList          ("zMinusList"          , parsedOnly())
   {}
 
 

--- a/include/tk2CMSSW_strings.hh
+++ b/include/tk2CMSSW_strings.hh
@@ -22,10 +22,11 @@ namespace insur {
     static const double xml_outerTrackerEndcapsMinZ = 1250.;
     static const double xml_innerTrackerEndcapsMinZ = 227.;    // from PIXEL 4_0_2_1 onwards  // PIXEL 1_1_1 : 300.
     static const double xml_innerTiltedTrackerEndcapsMinZ = 415.; // 390. for IT_500
-    static const std::string xml_trackerOutermostRadius = "122.15*cm"; // Outermost tracker volume boundary
-
-    /**
-     * XML tags and attributes
+  //  static const std::string xml_trackerOutermostRadius = "122.15*cm"; // Outermost tracker volume boundary
+    static const std::string xml_trackerOutermostRadius = "1233*mm";
+     static const std::string xml_trackerInnermostRadius = "25*mm"; // Outermost tracker volume updated to reach CALO (https://github.com/cms-sw/cmssw/pull/43133)
+    static const std::string xml_trackerMaximumZ = "2935*mm";
+     /* XML tags and attributes
      */
     static const std::string xml_preamble_concise = "<?xml ";
     static const std::string xml_preamble = "<?xml version=\"1.0\"?>\n";
@@ -33,7 +34,8 @@ namespace insur {
     static const std::string xml_defclose = "</DDDefinition>\n";
     static const std::string xml_general_inter = "\">\n";
     static const std::string xml_general_endline = "\"/>\n";
-    static const std::string xml_const_section = "<ConstantsSection label=\"tracker.xml\" eval=\"true\">\n<Constant name=\"BackPlaneDz\" value=\"0.015*mm\"/>\n<Constant name=\"TrackerOutermostRadius\" value=\"" + xml_trackerOutermostRadius + "\"/>\n</ConstantsSection>\n";
+    //static const std::string xml_const_section = "<ConstantsSection label=\"tracker.xml\" eval=\"true\">\n<Constant name=\"BackPlaneDz\" value=\"0.015*mm\"/>\n<Constant name=\"TrackerOutermostRadius\" value=\"" + xml_trackerOutermostRadius + "\"/>\n</ConstantsSection>\n";
+    static const std::string xml_const_section = "<ConstantsSection label=\"tracker.xml\" eval=\"true\">\n<Constant name=\"BackPlaneDz\" value=\"0.015*mm\"/>\n<Constant name=\"TrackerMaximumZ\" value=\"" + xml_trackerMaximumZ +"\"/>\n<Constant name=\"TrackerMinimumZ\" value=\"-[TrackerMaximumZ]\"/>\n<Constant name=\"TrackerInnermostRadius\" value=\"" + xml_trackerInnermostRadius +"\"/>\n<Constant name=\"TrackerOutermostRadius\" value=\"" + xml_trackerOutermostRadius + "\"/>\n</ConstantsSection>\n";                         
     static const std::string xml_new_const_section = "<ConstantsSection label=\"newtracker.xml\" eval=\"true\">\n<Constant name=\"newDummyBackPlaneDz\" value=\"0.015*mm\"/>\n</ConstantsSection>\n";
     static const std::string xml_recomat_parameters = "<Parameter name=\"TrackerRadLength\" value=\"0.01\"/>\n<Parameter name=\"TrackerXi\" value=\"0.0001";
     static const std::string xml_recomat_radlength = "TrackerRadLength";
@@ -102,7 +104,7 @@ namespace insur {
     static const std::string xml_cone_fifth_inter = "*mm\" dz=\"";
     static const std::string xml_cone_close = "*mm\" startPhi=\"0*deg\" deltaPhi=\"360*deg\"/>\n";
     static const std::string xml_polycone_open = "<Polycone name=\"";
-    static const std::string xml_polycone_inter = "\" startPhi=\"0*deg\" deltaPhi=\"360*deg\">\n";
+    static const std::string xml_polycone_inter = "\" startPhi=\"0*deg\" deltaPhi=\"360*deg\">\n<ZSection z=\"[tracker:TrackerMinimumZ]\" rMin=\"[tracker:TrackerInnermostRadius]\" rMax=\"[tracker:TrackerOutermostRadius]\"/>\n<ZSection z=\"[tracker:TrackerMaximumZ]\" rMin=\"[tracker:TrackerInnermostRadius]\" rMax=\"[tracker:TrackerOutermostRadius]\"/>";
     static const std::string xml_polycone_close = "</Polycone>\n";
     static const std::string xml_rzpoint_open = "<RZPoint r=\"";
     static const std::string xml_rzpoint_inter = "*mm\" z=\"";

--- a/src/Vizard.cc
+++ b/src/Vizard.cc
@@ -7337,7 +7337,7 @@ namespace insur {
 
     RZCanvas.reset(new TCanvas("RZCanvas", "RZView Canvas",  insur::vis_max_canvas_sizeX, insur::vis_min_canvas_sizeY));
     RZCanvas->cd();
-    PlotDrawer<YZ, Type> yzDrawer;
+    PlotDrawer<YZFull, Type> yzDrawer;
     yzDrawer.addModules(tracker);
     yzDrawer.drawFrame<SummaryFrameStyle>(*RZCanvas.get());
     yzDrawer.drawModules<ContourStyle>(*RZCanvas.get());
@@ -7345,7 +7345,7 @@ namespace insur {
     double viewPortMax = MAX(tracker.barrels().at(0).maxR() * 1.1, tracker.barrels().at(0).maxZ() * 1.1); // Style to improve. Calculate (with margin) the barrel geometric extremum
     RZCanvasBarrel.reset(new TCanvas("RZCanvasBarrel", "RZView CanvasBarrel", vis_min_canvas_sizeX, vis_min_canvas_sizeY));
     RZCanvasBarrel->cd();
-    PlotDrawer<YZ, Type> yzDrawerBarrel(viewPortMax, viewPortMax);
+    PlotDrawer<YZFull, Type> yzDrawerBarrel(viewPortMax, viewPortMax);
     yzDrawerBarrel.addModulesType(tracker, BARREL);
     yzDrawerBarrel.drawFrame<SummaryFrameStyle>(*RZCanvasBarrel.get());
     yzDrawerBarrel.drawModules<ContourStyle>(*RZCanvasBarrel.get());

--- a/xml/trackerVolumeTemplate.xml
+++ b/xml/trackerVolumeTemplate.xml
@@ -2,21 +2,29 @@
      Tracker volume contains Inner Tracker + Outer Tracker + (BTL) + OTST.
      (BTL) is in parentheses as it is not included in all geometry scenarios.
      See Configuration/Geometry/README.md for more details.
+     15-11-23 - Configuration of Tracker volume changed (Polycone -> cylinder) following https://github.com/cms-sw/cmssw/pull/43133
 -->
 <Polycone name="<!--mid point marker-->" startPhi="0*deg" deltaPhi="360*deg">
-  <!-- TEMPORARY!! Should be defined automatically -->
+
+  <ZSection z="[tracker:TrackerMinimumZ]" rMin="[tracker:TrackerInnermostRadius]" rMax="[tracker:TrackerOutermostRadius]"/>
+  <ZSection z="[tracker:TrackerMaximumZ]" rMin="[tracker:TrackerInnermostRadius]" rMax="[tracker:TrackerOutermostRadius]"/>
+</Polycone>
+
+  <!-- TEMPORARY!! Should be defined automatically 
   <ZSection z="-291.0*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-276.9*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-276.9*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-150.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="-150.0*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>
-  <ZSection z="-22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>    <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="-41.50*cm" -->
-  <ZSection z="-22.70*cm" rMin="2.6*cm" rMax="[tracker:TrackerOutermostRadius]"/>    <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="-41.50*cm" -->
-  <ZSection z="22.70*cm" rMin="2.6*cm" rMax="[tracker:TrackerOutermostRadius]"/>     <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="41.50*cm" -->
-  <ZSection z="22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>     <!-- This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="41.50*cm" -->
+  <ZSection z="-22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>  This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="-41.50*cm" 
+  <ZSection z="-22.70*cm" rMin="2.6*cm" rMax="[tracker:TrackerOutermostRadius]"/> This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="-41.50*cm" 
+  <ZSection z="22.70*cm" rMin="2.6*cm" rMax="[tracker:TrackerOutermostRadius]"/>   
+ This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="41.50*cm"
+  <ZSection z="22.70*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>  
+This is for Pixel 4_0_2_5. For Tilted Inner Tracker 501 : z="41.50*cm"
   <ZSection z="150.0*cm" rMin="2.8*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="150.0*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="276.9*cm" rMin="6.23*cm" rMax="[tracker:TrackerOutermostRadius]"/>
   <ZSection z="276.9*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
-  <ZSection z="291.0*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/>
-</Polycone>
+  <ZSection z="291.0*cm" rMin="110.0*cm" rMax="[tracker:TrackerOutermostRadius]"/> -->
+  


### PR DESCRIPTION
- Added 2 properties to implement dZ BPX gap 
- Minors on graphics (mirror plots in -Z Z now  enabled)
- Update  XMLs constant strings + tracker volume template to match https://github.com/cms-sw/cmssw/pull/43133 tracker.xml file